### PR TITLE
Distribute package as a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Wheels are the standard of Python distribution. Advantages of wheels includes:

- Faster installation
- Avoids arbitrary code execution during installation by avoiding `setup.py`
- Allows better caching for testing and continuous integration
- Creates `.pyc` files as part of installation to ensure they match the Python interpreter used
- More consistent installs across platforms and machines

When you'd normally run `python setup.py sdist upload`, run instead `python setup.py sdist bdist_wheel upload`.

For additional information on wheels, see:

https://pythonwheels.com/

For full details on wheel, see PEP-427:

https://www.python.org/dev/peps/pep-0427/

The wheel includes the license file by using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file