### PR TITLE
Add static analysis checks to erezutils project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 __pycache__/
 
 *.egg-info/
+.tox
 build/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: python
+cache: pip
+
+install: pip install tox
+script: tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,14 @@ universal = 1
 
 [metadata]
 license_file = LICENSE
+
+[flake8]
+exclude =
+    .tox
+
+[isort]
+line_length = 79
+multi_line_output = 2
+not_skip = __init__.py
+skip =
+    .tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist =
+    flake8
+    isort
+
+[testenv:flake8]
+deps = flake8
+commands = flake8
+skip_install = true
+
+[testenv:isort]
+deps = isort
+commands = isort --check-only --diff
+skip_install = true


### PR DESCRIPTION
Use tox to build testing environments and to run a test matrix. Can run all testing with the single command:

```
  $ tox
```

tox is very popular and commonly used testing tool in the Python community.

Use Travis CI to verify PRs pass all tox targets pass.

From https://tox.readthedocs.io/

> What is tox?
>
> tox is a generic virtualenv management and test command line tool you can use for:
>
>    - checking your package installs correctly with different Python versions and interpreters
>    - running your tests in each of the environments, configuring your test tool of choice
>    - acting as a frontend to Continuous Integration servers, greatly reducing boilerplate and merging CI and shell-based testing.

---

If there is agreement on enabling this CI, I'll turn on Travis CI for this project.