### PR TITLE
DeprecationWarning: Import Mapping from collections.abc

### DIFF
--- a/erezutils.py
+++ b/erezutils.py
@@ -5,7 +5,7 @@ import hashlib
 def rupdate(d, u):
     """Recursively update dictionary d with the contents of u."""
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             v = rupdate(d.get(k, {}), v)
         d[k] = v
     return d


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated, and in 3.8 it will stop
working