### PR TITLE
Run static analysis before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ script: tox
 
 matrix:
   include:
+    - python: "3.6"
+      env: TOXENV=black
+    - python: "3.6"
+      env: TOXENV=flake8
+    - python: "3.6"
+      env: TOXENV=isort
     - python: "2.7"
       env:
         - TOXENV=py27
@@ -23,9 +29,3 @@ matrix:
         - TOXENV=py37
         - secure: TnI2dSGBAF6cE2iVnE7XQC/V50pHf2nwdHV1iTtEkfFp0DNeb8xrCwyML3SSXroEEn+HgVs6Jg+Xg9G5axo4A8EI3GE+COuP1E2Y10I7lutjf9xPep1VmFS13+xGBg9zX5xy7cSG33RgIaxhk6CLnBo5b8XoYRn2XlzNVTNJgHys+fSLX4RTlLDe3JvHBEb4ESQSk4gd2fKrDU1dIThwEmtFXukUxcfv8NEMihEgBEC93h2EmjGH2qD+hiG5ygiprDRClj8RgpsyuID2k+kII8wTHvWB9jlTDUv3Lp/cUeoUw6ATrMGv9/alaWnOJeVRJq4Zm9Yj8QpP88jVFhtgwHyJeaYA/vka5ZKvnpozrJPifAB0zLQZYT0HjWN2OuCvukKB2nVHmpUFPvhdZA+iMLyjMaakv7GSi8jU9rJntCfORQKWY9UU9l1NUOeHVjRLDHqCQsOdSwee9TeLeF1bWIVTUyhAdFyRksak9pUt0Lg/m3kMPyZ9kuiAx/dE+LcBBNsJ3rYboRdE+wvUhkmTkmHbshxUhgoHzRwjk3PO7h0IYnkmSzXddESiurvM5KkdXU7iiij/s9Y1Y/EGdiXA65xaXM/JSsOrnDUCUmX5Nsa1W2+W8qElqpKxiWXDI4B+DRtzu13zihAREFgkPwwjQbutRon9gV5FTNhnp5JWNAo=
         - secure: Q0vLWPzI5BQpkK306EqKKjI5ADPLvXNWSuPE6AKxgmUp2LvaQaI+yPX1BMkaXwAKCV1zcfGfm6c1MKMDiM8/ArTOCkZ9rOrIBqqCChc1N6gD/+LtRcU651V3Cd2CVmOPpo2SzsZrf8GdRi8aKh1Jb6JCxA+5wIhwqyH/OKbPfnHNG3OkMk/llvQsI7lZ1qi/2aUmaXvbFgW4H9hiPJHXb8oM1SGqbvlNc/ZCWeFknDJ4hbxQMPR9PYNlDJDmr8d8/Ex9sIxc+bfxVqkEAWUfdoITV5FMCPvYVQS5ex1IpJcUX8BDEmoAPTahW1txoG/KV9v6YLxhJOz7q75L17fE8vrYDGy/ZIOZ0KCknXQOAPFqwpnb3TNOmkCYO++s9HJQI72P34vvBlM7clpEARm3Ucxrd6B7w3TCUjbjec5x6bdV0l1ZZ9En2b19Kr+a2lS/OZ+ie7fthYAIxXb4+KiQt1AciQg2+wt/MUNKZazrjtuovXQdqMAh5Hu3WyqgoDG+8i7ducbZaeADaacWSQHP/xn7ughKXuI6oVuCNExahxpPW/Z4KCXeEsQNG5PxQp/Gige+EbFC8rmAZAl56RwxRoS8pB0NYUVcKxnUEnCBo/yccVgWNzhf+AU90FtKRl62dJqeLDAzet+696/Uc/yTqgmc9uGQQJaaZ1EnTINh8Z8=
-    - python: "3.6"
-      env: TOXENV=black
-    - python: "3.6"
-      env: TOXENV=flake8
-    - python: "3.6"
-      env: TOXENV=isort

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
 envlist =
-    py27
-    py36
-    py37
     black
     flake8
     isort
+    py{27,36,37}
 
 [testenv]
 # Remove "discover" when Python 2 support is dropped.


### PR DESCRIPTION
Typically, as a test suite grows, tests require more time than static
analysis checks. If a formatting error can be reported early, do it.