### PR TITLE
Remove default configurations from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,12 +7,7 @@ license_file = LICENSE
 [flake8]
 max-line-length = 88
 ignore = E203
-exclude =
-    .tox
 
 [isort]
 line_length = 88
 multi_line_output = 2
-not_skip = __init__.py
-skip =
-    .tox


### PR DESCRIPTION
Both flake8 and isort ignore ".tox" by default.

isort no longer skips `__init__.py` by default.