### PR TITLE
Remove 'dist: xenial' from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: python
 cache: pip
 


### PR DESCRIPTION
It is now the default.