### PR TITLE
Simplify Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,9 @@ script: tox
 
 matrix:
   include:
-    - python: "3.6"
-      env: TOXENV=black
-    - python: "3.6"
-      env: TOXENV=flake8
-    - python: "3.6"
-      env: TOXENV=isort
+    - env: TOXENV=black
+    - env: TOXENV=flake8
+    - env: TOXENV=isort
     - python: "3.6"
       env:
         - TOXENV=py36


### PR DESCRIPTION
Travis now defaults to Python 3.6