### PR TITLE
Add new utility context manager pgpass

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,6 @@ max-line-length = 88
 ignore = E203
 
 [isort]
+include_trailing_comma = true
 line_length = 88
-multi_line_output = 2
+multi_line_output = 3


### PR DESCRIPTION
This context manager takes a list of "configs". Each is a dict
containing PostgreSQL connection information. The context manager writes
out a temporary file in the PostgreSQL password file format and then
yields the temporary file's path. Upon exit, the file is cleaned up.