### PR TITLE
Use setuptools declarative syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,27 @@
+[metadata]
+name = erezutils
+version = 1.1.0
+license = MIT
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3 :: Only
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Utilities
+
+[options]
+python_requires = >=3.6
+install_requires =
+    boto3
+py_modules =
+    erezutils
+
 [flake8]
 max-line-length = 88
 ignore = E203

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,3 @@
 from setuptools import setup
 
-setup(
-    name="erezutils",
-    version="1.1.0",
-    py_modules=["erezutils"],
-    install_requires=["boto3"],
-    python_requires=">=3.6",
-    license="MIT",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3 :: Only",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Utilities",
-    ],
-)
+setup()


### PR DESCRIPTION
https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files

Reduces the mixing code and configuration by using a no-logic
declarative syntax.