### PR TITLE
Bump version to prepare for next release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = erezutils
-version = 1.1.0
+version = 2.0.0
 license = MIT
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Breaking changes:

- Dropped support for Python 2
- Removed function hashfiles()

Reviewed-by: François Freitag