### PR TITLE
Use PEP518 pyproject.toml to create dist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
Setup.py is basically deprecated.
https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

Reviewed-by: blissdev