### PR TITLE
Configure tox to use PEP 517 and PEP 518 builds

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     black
     flake8
     isort
+isolated_build = True
 minversion = 1.9
 
 [testenv]


### PR DESCRIPTION
Introduced in 1ec3243563be76190c520612e3cd45cb11fd82fa.

From https://tox.wiki/en/latest/example/package.html:

> To create a source distribution there are multiple tools out there and
  with PEP-517 and PEP-518 you can easily use your favorite one with
  tox. Historically tox only supported setuptools, and always used the
  tox host environment to build a source distribution from the source
  tree. This is still the default behavior. To opt out of this behaviour
  you need to set isolated builds to true.

Reviewed-by: blissdev