### PR TITLE
Revert "Merge user ~/.pgpass with erezutils.pgpass"

### DIFF
--- a/erezutils.py
+++ b/erezutils.py
@@ -1,5 +1,4 @@
 import contextlib
-import pathlib
 import tempfile
 from collections.abc import Mapping
 
@@ -43,15 +42,6 @@ def pgpass_escape(s):
 @contextlib.contextmanager
 def pgpass(configs):
     with tempfile.NamedTemporaryFile("w") as f:
-        user_pgpass = pathlib.Path().home() / ".pgpass"
-        try:
-            content = user_pgpass.read_text()
-        except FileNotFoundError:
-            pass
-        else:
-            f.write(content)
-            if not content.endswith("\n"):
-                f.write("\n")
         for config in configs:
             f.write(
                 "%s:*:%s:%s:%s\n"

--- a/test_erezutils.py
+++ b/test_erezutils.py
@@ -1,7 +1,5 @@
 import os
-import tempfile
 import unittest
-import unittest.mock
 import uuid
 from pathlib import Path
 
@@ -160,53 +158,3 @@ class PGPassTest(unittest.TestCase):
                 content,
             )
         self.assertFalse(os.path.exists(path))
-
-    def test_merges_with_user_pgpass(self):
-        with tempfile.TemporaryDirectory() as testdir_cm:
-            testdir = Path(testdir_cm)
-            with unittest.mock.patch("pathlib.Path.home", return_value=testdir):
-                home_pgpass_path = testdir / ".pgpass"
-                with open(home_pgpass_path, "w") as home_pgpass:
-                    home_pgpass.write("somehost:*:dbname:username:Passw0rd!\n")
-                config = [
-                    {
-                        "name": "db1",
-                        "user": "admin1",
-                        "password": "hunter2",
-                        "host": "localhost",
-                    }
-                ]
-                with pgpass(config) as path:
-                    content = Path(path).read_bytes()
-                    self.assertEqual(
-                        b"somehost:*:dbname:username:Passw0rd!\n"
-                        b"localhost:*:db1:admin1:hunter2\n",
-                        content,
-                    )
-                self.assertFalse(os.path.exists(path))
-                self.assertTrue(home_pgpass_path.exists())
-
-    def test_merges_with_user_pgpass_without_line_return(self):
-        with tempfile.TemporaryDirectory() as testdir_cm:
-            testdir = Path(testdir_cm)
-            with unittest.mock.patch("pathlib.Path.home", return_value=testdir):
-                home_pgpass_path = testdir / ".pgpass"
-                with open(home_pgpass_path, "w") as home_pgpass:
-                    home_pgpass.write("somehost:*:dbname:username:Passw0rd!")
-                config = [
-                    {
-                        "name": "db1",
-                        "user": "admin1",
-                        "password": "hunter2",
-                        "host": "localhost",
-                    }
-                ]
-                with pgpass(config) as path:
-                    content = Path(path).read_bytes()
-                    self.assertEqual(
-                        b"somehost:*:dbname:username:Passw0rd!\n"
-                        b"localhost:*:db1:admin1:hunter2\n",
-                        content,
-                    )
-                self.assertFalse(os.path.exists(path))
-                self.assertTrue(home_pgpass_path.exists())


### PR DESCRIPTION
This reverts commit 9f4bd166e7affe555010df673d18d1e73baa9e72.
This feature is no longer needed.

Reviewed-by: blissdev