### PR TITLE
Drop support for EOL Python 3.6 and Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
-          - 3.7
           - 3.8
           - 3.9
           - "3.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -18,7 +16,7 @@ classifiers =
     Topic :: Utilities
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.8
 install_requires =
     boto3
 py_modules =

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ passenv =
     AWS_SECRET_ACCESS_KEY
 
 [testenv:black]
-commands = black --target-version py36 --check --diff .
+commands = black --target-version py38 --check --diff .
 deps = black
 skip_install = true
 


### PR DESCRIPTION
Python 3.7 is no longer supported by eRezLife.

Reviewed-by: blissdev
